### PR TITLE
Left Stick Drive Default (with left/right stick option configuration feature)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,54 +63,54 @@ It is strongly recommended that you read this guide completely a few times befor
 
 - ### Arduino Uno (Option 1)
 
-      	For the body. Main Arduino that runs everything. Receivers, code, connection to MP3 trigger, etc runs through here. SparkFun, RadioShack, Amazon, you can find these everywhere these days.
+      For the body. Main Arduino that runs everything. Receivers, code, connection to MP3 trigger, etc runs through here. SparkFun, RadioShack, Amazon, you can find these everywhere these days.
 
 - ### Arduino Mega (Option 2 and Recommended!)
 
-      	I run a Mega for the body. It uses the hardware serial pins to connect to the motor controllers. Better performance and memory utilization. The Mega has more memory available too so there's more room to expand and do more if you want. With the Mega, I can also support I2C a bit better.
+      I run a Mega for the body. It uses the hardware serial pins to connect to the motor controllers. Better performance and memory utilization. The Mega has more memory available too so there's more room to expand and do more if you want. With the Mega, I can also support I2C a bit better.
 
 - ### USB Shield
 
-      	Sourced from [Circuits@Home](https://www.circuitsathome.com/products-page/arduino-shields). They've shuffled their links around. Find it on that link labeled "USB Host Shield 2.0 for Arduino – Assembled". They used to offer it assembled and unassembled but as of this writing, they just have it assembled.
+  Sourced from [Circuits@Home](https://www.circuitsathome.com/products-page/arduino-shields). They've shuffled their links around. Find it on that link labeled "USB Host Shield 2.0 for Arduino – Assembled". They used to offer it assembled and unassembled but as of this writing, they just have it assembled.
 
-      	If Amazon is your thing Sainsmart has a USB Host Shield that has been found to be compatible with Padawan360 (Prime elligble!)
-      	[SainSmart USB Shield](http://www.amazon.com/SainSmart-Compatible-HOST-Shield-Arduino/dp/B006J4G000/ref=sr_1_1?ie=UTF8&qid=1420994477&sr=8-1&keywords=usb+host+shield+2.0+for+arduino). *NOTE* I've seen that some SainSmart isn't sending them with the 2x3 headers that connects the shield to the Arduino board together. This connection is absolutely necessary for the Arduino to talk to the shield over serial (ISCP pins). It will NOT work without this connection. Real dumb. The shield is basically useless without the connection. I spent a while a DroidCon trying to help someone it before realizing that was missing and it's absolutely necessary. You can grab 2x3 headers from Sparkfun for 50 cents. The missing headers seem to be a common issue as the Aamazon reviews are rife with that complaint.
+  If Amazon is your thing Sainsmart has a USB Host Shield that has been found to be compatible with Padawan360 (Prime elligble!) SainSmart USB Shield](http://www.amazon.com/SainSmart-Compatible-HOST-Shield-Arduino/dp/B006J4G000/ref=sr_1_1?ie=UTF8&qid=1420994477&sr=8-1&keywords=usb+host+shield+2.0+for+arduino). *NOTE* I've seen that some SainSmart isn't sending them with the 2x3 headers that connects the shield to the Arduino board together. This connection is absolutely necessary for the Arduino to talk to the shield over serial (ISCP pins). It will NOT work without this connection. Real dumb. The shield is basically useless without the connection. I spent a while a DroidCon trying to help someone it before realizing that was missing and it's absolutely necessary. You can grab 2x3 headers from Sparkfun for 50 cents. The missing headers seem to be a common issue as the Aamazon reviews are rife with that complaint.
 
 - ### Xbox 360 Wireless USB Receiver
 
-      	You can probably source this from Best Buy or something local but it's available on [NewEgg here](http://www.newegg.com/Product/Product.aspx?Item=0NS-000Z-00003)
-      	I bought a generic one from Microcenter that works fine. Some users have gotten cheap ones from Ebay from off-brands that did not function. I highly recommend buying 1st party official Microsoft receiver. Your mileage may vary with off-brand components here.
+  You can probably source this from Best Buy or something local but it's available on [NewEgg here](http://www.newegg.com/Product/Product.aspx?Item=0NS-000Z-00003)
+      
+  I bought a generic one from Microcenter that works fine. Some users have gotten cheap ones from Ebay from off-brands that did not function. I highly recommend buying 1st party official Microsoft receiver. Your mileage may vary with off-brand components here.
 
 - ### Xbox 360 Wireless Controller
 
-      	[Controller via Amazon](http://www.amazon.com/Xbox-360-Wireless-Controller-Glossy-Black/dp/B003ZSP0WW).  I have a nice blue one to match R2 personally ;) Like the USB Receiver, I highly recommend buying a 1st party official Microsoft controller. I know one user bought one cheap on Ebay and it didn't even have a sync button and there was no X on the center Home button. Your mileage may vary with off-brand components here.
+  [Controller via Amazon](http://www.amazon.com/Xbox-360-Wireless-Controller-Glossy-Black/dp/B003ZSP0WW).  I have a nice blue one to match R2 personally ;) Like the USB Receiver, I highly recommend buying a 1st party official Microsoft controller. I know one user bought one cheap on Ebay and it didn't even have a sync button and there was no X on the center Home button. Your mileage may vary with off-brand components here.
 
-      	**Note:** I have seen the controller bundled with the USB receiver together. It was in the gaming peripheals department in my local Microcenter. It's marketed for PC gaming. Nice to get it in one package if you can if you don't have an extra 360 controller to spare.
+  **Note:** I have seen the controller bundled with the USB receiver together. It was in the gaming peripheals department in my local Microcenter. It's marketed for PC gaming. Nice to get it in one package if you can if you don't have an extra 360 controller to spare.
 
 - ### MP3 Trigger
 
-      	[Sourced from SparkFun](https://www.sparkfun.com/products/11029). Be sure to get a microSD card too. Nothing too big, it's just MP3s.
+  [Sourced from SparkFun](https://www.sparkfun.com/products/11029). Be sure to get a microSD card too. Nothing too big, it's just MP3s.
 
 - ### Sabertooth Motor Controller - Feet
 
-      	Depending on your motors you'll want a  [Sabertooth 2x32](https://www.dimensionengineering.com/products/sabertooth2x32), [Sabertooth 2x25](https://www.dimensionengineering.com/products/sabertooth2x25) or [2x12](https://www.dimensionengineering.com/products/sabertooth2x12). The 2x32 and the 2x24 seem to be crossing over price point. Might as well get the 2x32 if you're buying brand new. There's some additional bells and whistles in the 32 and can be programmed via Dimension Engineering's software, but some of those usefuls features are handled in the code, like for speed Ramping for example. My styrene droid with Jaycar motors uses 2x12. Most people tend to use 2x25 or 2x32 for scooter motors and NPC motors. Consult with Dimension Engineering to make sure you get the right one you need. Either one will work with the code
+  Depending on your motors you'll want a  [Sabertooth 2x32](https://www.dimensionengineering.com/products/sabertooth2x32), [Sabertooth 2x25](https://www.dimensionengineering.com/products/sabertooth2x25) or [2x12](https://www.dimensionengineering.com/products/sabertooth2x12). The 2x32 and the 2x24 seem to be crossing over price point. Might as well get the 2x32 if you're buying brand new. There's some additional bells and whistles in the 32 and can be programmed via Dimension Engineering's software, but some of those usefuls features are handled in the code, like for speed Ramping for example. My styrene droid with Jaycar motors uses 2x12. Most people tend to use 2x25 or 2x32 for scooter motors and NPC motors. Consult with Dimension Engineering to make sure you get the right one you need. Either one will work with the code
 
 - ### Syren Motor Controller - Dome
 
-      	[Syren 10](https://www.dimensionengineering.com/products/syren10)
+  [Syren 10](https://www.dimensionengineering.com/products/syren10)
 
 - ### Amp and Speakers
 
-      	Up to you and how big and loud you want. I have a small speaker and a $20 amp from Pyle. A ground loop isolator might be necessary to protect the MP3 trigger and eliminate buzzing from the speaker.
+  Up to you and how big and loud you want. I have a small speaker and a $20 amp from Pyle. A ground loop isolator might be necessary to protect the MP3 trigger and eliminate buzzing from the speaker.
 
 - ### Teeces lights
 
-      	The sketch provided here will work for version 3 of the Teeces lighting system for Logic Lights. Use the regular setup and installation instructions for the Teeces system. To control brightness and changing the lighting animations that match some scenes from the films (like the flicker pattern during the Leia Message), the Arduino for the Teeces system needs to be connected to the body Arduino via I2C. Connect the I2C pins from the Body Arduino to the Teeces Arduino. SDA->SDA pins and SCL->SCL pins. On the Uno these are A4 and A5 respectively and on the Mega they are 20 and 21. Verify the I2C pins on your Teeces Arduino. These can be connected via a slipring.
+  The sketch provided here will work for version 3 of the Teeces lighting system for Logic Lights. Use the regular setup and installation instructions for the Teeces system. To control brightness and changing the lighting animations that match some scenes from the films (like the flicker pattern during the Leia Message), the Arduino for the Teeces system needs to be connected to the body Arduino via I2C. Connect the I2C pins from the Body Arduino to the Teeces Arduino. SDA->SDA pins and SCL->SCL pins. On the Uno these are A4 and A5 respectively and on the Mega they are 20 and 21. Verify the I2C pins on your Teeces Arduino. These can be connected via a slipring.
 
 - #### Optional
 
   - ##### RSeries RGB HPs.
-
+  
     Sketches provided are for I2C holoprojector boards. The front uses the one with the servo pinouts although the sketch doesn't servo control of the HPs. The top and rear HP are just the regular I2C controlled boards.
 
   - ##### Slipring

--- a/README.md
+++ b/README.md
@@ -317,6 +317,8 @@ Some users had experienced some issues of sounds freezing up and going a bit hay
 
 If the wrong sounds are playing for button presses, they are likely added to the SD card in the wrong order. They must be put on the card in the exact order one at a time or by using Drivesort. Reference [this video](https://youtu.be/UsMI2gW7Q40) for how load the sound files up with Drivesort to ensure they're loaded onto the SD Card in proper order.
 
+Loading the sound files must be done with a Windows PC. Unfortunately, MacOS will leave some helper index files to inprove OS features like Spotlight and other assorted MacOS specific things. If anyone has done this on a Mac, please let me know!! Likely this can be done on Linux, but I've yet to do it personally. If you have, please let me know.
+
 ### Dome
 
 _**My Dome just randomly spins! My Dome won't spin! My Dome doesn't spin correctly** etc etc.._

--- a/README.md
+++ b/README.md
@@ -1,50 +1,50 @@
-Padawan360
-====
+# Padawan360
 
 Still to come - servo control.
 
-
 - [Padawan360](#padawan360)
-  * [Intro](#intro)
-  * [Components](#components)
-    + [Arduino Uno (Option 1)](#arduino-uno--option-1-)
-    + [Arduino Mega (Option 2 and Recommended!)](#arduino-mega--option-2-and-recommended--)
-    + [USB Shield](#usb-shield)
-    + [Xbox 360 Wireless USB Receiver](#xbox-360-wireless-usb-receiver)
-    + [Xbox 360 Wireless Controller](#xbox-360-wireless-controller)
-    + [MP3 Trigger](#mp3-trigger)
-    + [Sabertooth Motor Controller - Feet](#sabertooth-motor-controller---feet)
-    + [Syren Motor Controller - Dome](#syren-motor-controller---dome)
-    + [Amp and Speakers](#amp-and-speakers)
-    + [Teeces lights](#teeces-lights)
-      - [Optional](#optional)
-        * [RSeries RGB HPs.](#rseries-rgb-hps)
-        * [Slipring](#slipring)
-  * [Setup](#setup)
-    + [Arduino IDE](#arduino-ide)
-    + [USB Shield](#usb-shield-1)
-    + [Sound](#sound)
-      - [Troubleshooting](#troubleshooting)
-    + [Dome](#dome)
-      - [Option 1](#option-1)
-      - [Option 2 (Best Option)](#option-2--best-option-)
-      - [Dome Troubleshooting](#dome-troubleshooting)
-    + [Foot Drive](#foot-drive)
-      - [Drive FAQs](#drive-faqs)
-    + [Arduino UNO/MEGA](#arduino-uno-mega)
-      - [I2C](#i2c)
-    + [Controller Pairing](#controller-pairing)
-      - [Troubleshooting](#troubleshooting-1)
-    + [Teeces Logics](#teeces-logics)
-    + [HoloProjectors I2C](#holoprojectors-i2c)
-  * [Controls](#controls)
-    + [Controller LED Status](#controller-led-status)
-    + [Button Guide](#button-guide)
-  * [Coming Soon](#coming-soon)
-  * [Licensing](#licensing)
-
+- [Intro](#intro)
+- [Components](#components)
+  - [Arduino Uno (Option 1)](#arduino-uno--option-1-)
+  - [Arduino Mega (Option 2 and Recommended!)](#arduino-mega--option-2-and-recommended--)
+  - [USB Shield](#usb-shield)
+  - [Xbox 360 Wireless USB Receiver](#xbox-360-wireless-usb-receiver)
+  - [Xbox 360 Wireless Controller](#xbox-360-wireless-controller)
+  - [MP3 Trigger](#mp3-trigger)
+  - [Sabertooth Motor Controller - Feet](#sabertooth-motor-controller---feet)
+  - [Syren Motor Controller - Dome](#syren-motor-controller---dome)
+  - [Amp and Speakers](#amp-and-speakers)
+  - [Teeces lights](#teeces-lights)
+    - [Optional](#optional)
+      - [RSeries RGB HPs.](#rseries-rgb-hps)
+      - [Slipring](#slipring)
+- [Setup](#setup)
+  - [Arduino IDE](#arduino-ide)
+  - [USB Shield](#usb-shield-1)
+  - [Sound](#sound)
+  - [Dome](#dome)
+    - [Option 1](#option-1)
+    - [Option 2 (Best Option)](#option-2--best-option-)
+  - [Foot Drive](#foot-drive)
+  - [Arduino UNO/MEGA](#arduino-uno-mega)
+    - [I2C](#i2c)
+  - [Controller Pairing](#controller-pairing)
+  - [Options, Configurations, and Settings](#options--configurations--and-settings)
+  - [Teeces Logics](#teeces-logics)
+  - [HoloProjectors I2C](#holoprojectors-i2c)
+- [Controls](#controls)
+  - [Controller LED Status](#controller-led-status)
+  - [Button Guide](#button-guide)
+- [Troubleshooting and FAQs](#troubleshooting-and-faqs)
+  - [General Control Issues](#general-control-issues)
+  - [Sound](#sound-1)
+  - [Dome](#dome-1)
+  - [Drives](#drives)
+- [Coming Soon](#coming-soon)
+- [Licensing](#licensing)
 
 ## Intro
+
 This is a control system for 1:1 scale remote control R2-D2 powered by Arduinos and controlled with an Xbox 360 Controller. It triggers lights, sounds, and controls foot drive and dome drive motors. It also supports I2C to trigger events in the dome lights or can be extended to interact with anything else that supports I2C
 
 These sketches are heavily based on DanF's Padawan control system that uses Playstation 2 controllers. I found the PS2 controllers to become a bit unreliable and they are increasingly more difficult to come by. I'm also taking advantage of the LEDs around the center Guide button to indicate state of the drive mode (disengaged, engaged w/ speed setting).
@@ -55,52 +55,66 @@ I developed Padawan360 (named with permission from DanF) to use some more easily
 
 A lot of the instructions here are relevant to the original [Padawan PS2](http://astromech.net/droidwiki/index.php?title=PADAWAN) setup instructions. A good chunk of the documentation is reproduced here.
 
+It is strongly recommended that you read this guide completely a few times before plugging things in or trying to run things.
+
 [The thread on Astromech for Padawan360 can be found here ](http://astromech.net/forums/showthread.php?t=19263_)
 
 ## Components
 
 - ### Arduino Uno (Option 1)
-	For the body. Main Arduino that runs everything. Receivers, code, connection to MP3 trigger, etc runs through here. SparkFun, RadioShack, Amazon, you can find these everywhere these days.
+
+      	For the body. Main Arduino that runs everything. Receivers, code, connection to MP3 trigger, etc runs through here. SparkFun, RadioShack, Amazon, you can find these everywhere these days.
 
 - ### Arduino Mega (Option 2 and Recommended!)
-	I run a Mega for the body. It uses the hardware serial pins to connect to the motor controllers. Better performance and memory utilization. The Mega has more memory available too so there's more room to expand and do more if you want. With the Mega, I can also support I2C a bit better.
+
+      	I run a Mega for the body. It uses the hardware serial pins to connect to the motor controllers. Better performance and memory utilization. The Mega has more memory available too so there's more room to expand and do more if you want. With the Mega, I can also support I2C a bit better.
 
 - ### USB Shield
-	Sourced from [Circuits@Home](https://www.circuitsathome.com/products-page/arduino-shields). They've shuffled their links around. Find it on that link labeled "USB Host Shield 2.0 for Arduino – Assembled". They used to offer it assembled and unassembled but as of this writing, they just have it assembled.
 
-	If Amazon is your thing Sainsmart has a USB Host Shield that has been found to be compatible with Padawan360 (Prime elligble!)
-	[SainSmart USB Shield](http://www.amazon.com/SainSmart-Compatible-HOST-Shield-Arduino/dp/B006J4G000/ref=sr_1_1?ie=UTF8&qid=1420994477&sr=8-1&keywords=usb+host+shield+2.0+for+arduino). *NOTE* I've seen that some SainSmart isn't sending them with the 2x3 headers that connects the shield to the Arduino board together. This connection is absolutely necessary for the Arduino to talk to the shield over serial (ISCP pins). It will NOT work without this connection. Real dumb. The shield is basically useless without the connection. I spent a while a DroidCon trying to help someone it before realizing that was missing and it's absolutely necessary. You can grab 2x3 headers from Sparkfun for 50 cents. The missing headers seem to be a common issue as the Aamazon reviews are rife with that complaint.
+      	Sourced from [Circuits@Home](https://www.circuitsathome.com/products-page/arduino-shields). They've shuffled their links around. Find it on that link labeled "USB Host Shield 2.0 for Arduino – Assembled". They used to offer it assembled and unassembled but as of this writing, they just have it assembled.
+
+      	If Amazon is your thing Sainsmart has a USB Host Shield that has been found to be compatible with Padawan360 (Prime elligble!)
+      	[SainSmart USB Shield](http://www.amazon.com/SainSmart-Compatible-HOST-Shield-Arduino/dp/B006J4G000/ref=sr_1_1?ie=UTF8&qid=1420994477&sr=8-1&keywords=usb+host+shield+2.0+for+arduino). *NOTE* I've seen that some SainSmart isn't sending them with the 2x3 headers that connects the shield to the Arduino board together. This connection is absolutely necessary for the Arduino to talk to the shield over serial (ISCP pins). It will NOT work without this connection. Real dumb. The shield is basically useless without the connection. I spent a while a DroidCon trying to help someone it before realizing that was missing and it's absolutely necessary. You can grab 2x3 headers from Sparkfun for 50 cents. The missing headers seem to be a common issue as the Aamazon reviews are rife with that complaint.
 
 - ### Xbox 360 Wireless USB Receiver
-	You can probably source this from Best Buy or something local but it's available on [NewEgg here](http://www.newegg.com/Product/Product.aspx?Item=0NS-000Z-00003)
-	I bought a generic one from Microcenter that works fine. Some users have gotten cheap ones from Ebay from off-brands that did not function. I highly recommend buying 1st party official Microsoft receiver. Your mileage may vary with off-brand components here.
+
+      	You can probably source this from Best Buy or something local but it's available on [NewEgg here](http://www.newegg.com/Product/Product.aspx?Item=0NS-000Z-00003)
+      	I bought a generic one from Microcenter that works fine. Some users have gotten cheap ones from Ebay from off-brands that did not function. I highly recommend buying 1st party official Microsoft receiver. Your mileage may vary with off-brand components here.
 
 - ### Xbox 360 Wireless Controller
-	[Controller via Amazon](http://www.amazon.com/Xbox-360-Wireless-Controller-Glossy-Black/dp/B003ZSP0WW).  I have a nice blue one to match R2 personally ;) Like the USB Receiver, I highly recommend buying a 1st party official Microsoft controller. I know one user bought one cheap on Ebay and it didn't even have a sync button and there was no X on the center Home button. Your mileage may vary with off-brand components here.
 
-	**Note:** I have seen the controller bundled with the USB receiver together. It was in the gaming peripheals department in my local Microcenter. It's marketed for PC gaming. Nice to get it in one package if you can if you don't have an extra 360 controller to spare.
+      	[Controller via Amazon](http://www.amazon.com/Xbox-360-Wireless-Controller-Glossy-Black/dp/B003ZSP0WW).  I have a nice blue one to match R2 personally ;) Like the USB Receiver, I highly recommend buying a 1st party official Microsoft controller. I know one user bought one cheap on Ebay and it didn't even have a sync button and there was no X on the center Home button. Your mileage may vary with off-brand components here.
+
+      	**Note:** I have seen the controller bundled with the USB receiver together. It was in the gaming peripheals department in my local Microcenter. It's marketed for PC gaming. Nice to get it in one package if you can if you don't have an extra 360 controller to spare.
 
 - ### MP3 Trigger
-	[Sourced from SparkFun](https://www.sparkfun.com/products/11029). Be sure to get a microSD card too. Nothing too big, it's just MP3s.
+
+      	[Sourced from SparkFun](https://www.sparkfun.com/products/11029). Be sure to get a microSD card too. Nothing too big, it's just MP3s.
 
 - ### Sabertooth Motor Controller - Feet
-	Depending on your motors you'll want a  [Sabertooth 2x32](https://www.dimensionengineering.com/products/sabertooth2x32), [Sabertooth 2x25](https://www.dimensionengineering.com/products/sabertooth2x25) or [2x12](https://www.dimensionengineering.com/products/sabertooth2x12). The 2x32 and the 2x24 seem to be crossing over price point. Might as well get the 2x32 if you're buying brand new. There's some additional bells and whistles in the 32 and can be programmed via Dimension Engineering's software, but some of those usefuls features are handled in the code, like for speed Ramping for example. My styrene droid with Jaycar motors uses 2x12. Most people tend to use 2x25 or 2x32 for scooter motors and NPC motors. Consult with Dimension Engineering to make sure you get the right one you need. Either one will work with the code
+
+      	Depending on your motors you'll want a  [Sabertooth 2x32](https://www.dimensionengineering.com/products/sabertooth2x32), [Sabertooth 2x25](https://www.dimensionengineering.com/products/sabertooth2x25) or [2x12](https://www.dimensionengineering.com/products/sabertooth2x12). The 2x32 and the 2x24 seem to be crossing over price point. Might as well get the 2x32 if you're buying brand new. There's some additional bells and whistles in the 32 and can be programmed via Dimension Engineering's software, but some of those usefuls features are handled in the code, like for speed Ramping for example. My styrene droid with Jaycar motors uses 2x12. Most people tend to use 2x25 or 2x32 for scooter motors and NPC motors. Consult with Dimension Engineering to make sure you get the right one you need. Either one will work with the code
 
 - ### Syren Motor Controller - Dome
-	[Syren 10](https://www.dimensionengineering.com/products/syren10)
+
+      	[Syren 10](https://www.dimensionengineering.com/products/syren10)
 
 - ### Amp and Speakers
-	Up to you and how big and loud you want. I have a small speaker and a $20 amp from Pyle. A ground loop isolator might be necessary to protect the MP3 trigger and eliminate buzzing from the speaker.
+
+      	Up to you and how big and loud you want. I have a small speaker and a $20 amp from Pyle. A ground loop isolator might be necessary to protect the MP3 trigger and eliminate buzzing from the speaker.
 
 - ### Teeces lights
-	The sketch provided here will work for version 3 of the Teeces lighting system for Logic Lights. Use the regular setup and installation instructions for the Teeces system. To control brightness and changing the lighting animations that match some scenes from the films (like the flicker pattern during the Leia Message), the Arduino for the Teeces system needs to be connected to the body Arduino via I2C. Connect the I2C pins from the Body Arduino to the Teeces Arduino. SDA->SDA pins and SCL->SCL pins. On the Uno these are A4 and A5 respectively and on the Mega they are 20 and 21. Verify the I2C pins on your Teeces Arduino. These can be connected via a slipring.
+
+      	The sketch provided here will work for version 3 of the Teeces lighting system for Logic Lights. Use the regular setup and installation instructions for the Teeces system. To control brightness and changing the lighting animations that match some scenes from the films (like the flicker pattern during the Leia Message), the Arduino for the Teeces system needs to be connected to the body Arduino via I2C. Connect the I2C pins from the Body Arduino to the Teeces Arduino. SDA->SDA pins and SCL->SCL pins. On the Uno these are A4 and A5 respectively and on the Mega they are 20 and 21. Verify the I2C pins on your Teeces Arduino. These can be connected via a slipring.
 
 - #### Optional
+
   - ##### RSeries RGB HPs.
-  Sketches provided are for I2C holoprojector boards. The front uses the one with the servo pinouts although the sketch doesn't servo control of the HPs. The top and rear HP are just the regular I2C controlled boards.
-  
+
+    Sketches provided are for I2C holoprojector boards. The front uses the one with the servo pinouts although the sketch doesn't servo control of the HPs. The top and rear HP are just the regular I2C controlled boards.
+
   - ##### Slipring
-  Used to pass power up from the body to the dome and also signal for I2C to control dome lights. The slipring allows wires to go from body to dome and allow the dome to spin 360 degrees without tangling the wires.
+    Used to pass power up from the body to the dome and also signal for I2C to control dome lights. The slipring allows wires to go from body to dome and allow the dome to spin 360 degrees without tangling the wires.
 
 ## Setup
 
@@ -120,11 +134,11 @@ If you're using the Mega, orient the USB ports to line up over each other.
 
 Connect the following pins from the MP3 Trigger to the Body Arduino
 
-|MP3 Trigger Pin   |Arduino UNO   |
-|---|---|
-| RX  |1   |
-| USBVCC  |5v   |
-| GND  |GND   |
+| MP3 Trigger Pin | Arduino UNO |
+| --------------- | ----------- |
+| RX              | 1           |
+| USBVCC          | 5v          |
+| GND             | GND         |
 
 **There is a small switch at the bottom of the board labled USB - EXT, make sure that it is pointing to the USB side in order to power it via the Arduino**
 
@@ -141,35 +155,31 @@ For anyone with an older version of the MP3Trigger board, you may need to upgrad
 3. Insert the microSD card into your MP3 Trigger and turn the power on while holding down the center navigation switch. Wait for the Status LED to go solid, then cycle the power.
 4. You’re now running the new firmware.
 
-#### Troubleshooting
-If the MP3 Trigger isn't functioning as expected, or at all, or just behaving a little "odd" - it would be good to make sure you have the most up to date firmware. Version 2.54 is known to work. It can be downloaded [here ](http://robertsonics.com/mp3-trigger-downloads/). The user manual has instruction for installation on the last page (as of this writing) of the instruction manual under "Bootloader". The manual is available from the previous link and also available directly [here](http://robertsonics.com/resources/mp3trigger/MP3TriggerV2UserGuide_2012-02-04.pdf)
-
-Some users had experienced some issues of sounds freezing up and going a bit haywire. It was resolved by using the barrel jack power connector as the Mp3Trigger was browning out. That means that disconnecting the 5v and Ground pins between the Arduino and MP3Trigger and switching flip the switch to EXT.
-
-If the wrong sounds are playing for button presses, they are likely added to the SD card in the wrong order. They must be put on the card in the exact order one at a time or by using Drivesort. Reference [this video](https://youtu.be/UsMI2gW7Q40) for how load the sound files up with Drivesort to ensure they're loaded onto the SD Card in proper order. 
-
 ### Dome
+
+Review the documentation made available by Dimension Engineering for the Syren Motor Controller.
+
 Connect the pins for the Syren Motor Controller
 
-|Syren10   |Arduino UNO   |
-|---|---|
-| S1  |5   |
-| 0v  |GND   |
+| Syren10 | Arduino UNO |
+| ------- | ----------- |
+| S1      | 5           |
+| 0v      | GND         |
 
-|Syren10   |Arduino Mega   |
-|---|---|
-| S1  |Serial2 (Tx2)  |
-| 0v  |GND   |
+| Syren10 | Arduino Mega  |
+| ------- | ------------- |
+| S1      | Serial2 (Tx2) |
+| 0v      | GND           |
 
-|Syren10   |Battery   |
-|---|---|
-| B+  |Positve   |
-| B-  |Negative   |
+| Syren10 | Battery  |
+| ------- | -------- |
+| B+      | Positve  |
+| B-      | Negative |
 
-|Syren10   |Dome Motor   |
-|---|---|
-| M1  |1 (Positve)   |
-| M2  |2 (Negative)   |
+| Syren10 | Dome Motor   |
+| ------- | ------------ |
+| M1      | 1 (Positve)  |
+| M2      | 2 (Negative) |
 
 If you find that the dome spins the opposite direction, flip M1 and M2. When standing behind the droid, moving left on the left analog stick should rotate the dome left.
 
@@ -178,9 +188,11 @@ Packetized is the best choice for the Syren, but you might need to change the ba
 If you can't get packetized to work, (and some people have had problems) you will have 2 options
 
 #### Option 1
+
 Simplified serial- easy to setup, proven to work, BUT a chance that the dome could start spinning if power is lost to the arduino but not the syren. While I haven't seen this happen without physically yanking the power wire or pressing the reset button the risk is there. I would say now that we know of this possibility, do not use this option if people, especially children, will be close enough to the droid to be injured. To use simplified serial, delete the // in front of the line #define SYRENSIMPLE at the beginning of the sketch.
 
 #### Option 2 (Best Option)
+
 Send the syren to Dimension Engineering to be flashed with the Ver. 2 firmware- This allows the syren to be locked in to a set baud rate and eliminates the auto-bauding problem. I have had this done to my own syren and have tested it with several types of arduinos with no problems. All new syrens are being shipped with this new firmware.
 
 The dip switches on the Syren should be set to 1 and 2 off for Packetized, or 2 and 4 off for Simple.
@@ -189,89 +201,65 @@ In some cases, we've noticed that the dome may behave eratically after starting 
 
 Make sure that you use at least a 14 Guage wire between the motor and the Syren 10. Anything hire can cause problems (fire!)
 
-#### Dome Troubleshooting
-**"My Dome just randomly spins!"** **My Dome won't spin!** **My Dome doesn't spin right** etc etc..
-
-Depending on the firmware on the Syren, sometimes you need to change the serial baud rate it communicates at. Change this like `const int DOMEBAUDRATE = 2400;` For packetized options are: 2400, 9600, 19200 and 38400
-
-**"The left analog stick is centered but the dome still spins!"**
-
-You need to just adjust the deadzone `const byte DOMEDEADZONERANGE = 20;` Increase this number until you can let the stick go neutral and nothing moves. The code has some more info on that above that line.
-
-
 ### Foot Drive
 
-|Sabertooth ((2x32 2x25 or 2x12)   |Arduino UNO   |
-|---|---|
-| S1  |4   |
-| S2  |3   |
-| 0v  |GND   |
+Review the documentation made available by Dimension Engineering for the Sabertooth Motor Controller.
 
-|Sabertooth ((2x32 2x25 or 2x12)   |Arduino Mega   |
-|---|---|
-| S1  |Serial1 (Tx1)  |
-| S2  |Serial1 (Rx1)   |
-| 0v  |GND   |
+Connect the pins for the Syren Motor Controller:
 
-|Sabertooth (2x32 2x25 or 2x12)   |Battery   |
-|---|---|
-| B+  |Positve   |
-| B-  |Negative   |
+| Sabertooth ((2x32 2x25 or 2x12) | Arduino UNO |
+| ------------------------------- | ----------- |
+| S1                              | 4           |
+| S2                              | 3           |
+| 0v                              | GND         |
 
-|Sabertooth ((2x32 2x25 or 2x12)   |Foot Motors   |
-|---|---|
-| M1A	  |Right Motor Terminal 1   |
-| M1B	  |Right Motor Terminal 2   |
-| M2A  |Left Motor Terminal 1  |
-| M2B  |Left Motor Terminal 2  |
+| Sabertooth ((2x32 2x25 or 2x12) | Arduino Mega  |
+| ------------------------------- | ------------- |
+| S1                              | Serial1 (Tx1) |
+| S2                              | Serial1 (Rx1) |
+| 0v                              | GND           |
 
-People often seem to get stuck here once they power everything up and find that they push forward on the stick and it drives to left, stick to the left drives drives backwards, etc. Don't fret, motors can be wired positive/negative. It doesn't matter. Start flipping the motor connections to the Sabertooth. First flip  M1A and M1B. If that doesn't fix it, flip it back and try the other. If it still isn't right, then try flipping both sets. R2 is driven like a tank. Spin the right motor forward to go left, left motor forward to go right. Both motors forward, drive forward. Keep that in mind as you troubleshoot.
+| Sabertooth (2x32 2x25 or 2x12) | Battery  |
+| ------------------------------ | -------- |
+| B+                             | Positve  |
+| B-                             | Negative |
 
+| Sabertooth ((2x32 2x25 or 2x12) | Foot Motors            |
+| ------------------------------- | ---------------------- |
+| M1A                             | Right Motor Terminal 1 |
+| M1B                             | Right Motor Terminal 2 |
+| M2A                             | Left Motor Terminal 1  |
+| M2B                             | Left Motor Terminal 2  |
 
 Please use a maximum of 12 Gauge for the wires going to the Sabertooth and motors/power.
 
-Sabertooth 2x32 / 2x25 / 2x12 dip switches should 1 & 2 OFF and all others ON if using a regular SLA battery
+Sabertooth 2x32 / 2x25 / 2x12 dip switches should 1 & 2 OFF and all others ON if using a regular SLA battery. If you're using Lithium-Ion batteries set switch #3 off also but consult your Sabertooth controller documentation.
 
 If you're using the 2x32 and you've tinkered with Dimension Engineering's DEScribe Software to tweak settings on your motor controller, under the Serial and USB tab, make sure the Baud Rate is set to 9600. This should be the default, but you should verify.
 
 If you're using 5v to power some components on your I2C device chain, you can use the 5V terminal on the Sabertooth and connect to the positive I2C pin header on the slipring board and 0V on the Sabertooth to GND on the slipring board.
 
-**Note:** If you're using Lithium-Ion batteries (you oddball!) set switch #3 off also.
-
-#### Drive FAQs
-
-Q: The right analog stick is centered but it still drives(turns, drives forward, drives reverse, etc)!
-
-A: You need to just adjust the deadzone `const byte DRIVEDEADZONERANGE = 20;` Increase this number until you can let the stick go neutral and nothing moves. The code has some more info on that above that line.
-
-
 ### Arduino UNO/MEGA
+
 Install the libraries from the Libraries folder. Upload the corresponding padawan360_body sketch from the `padawan360_body` folder for your Arduino (UNO or Mega) sketch to the Arduino. There is one for the UNO and one for the Mega.
 
-
 #### I2C
+
 This is optional. If you want to trigger light effects in the dome via slipring, connect A4 SLC to SLC on the slipring board and A5 SDA on the Arduino to SDA on the slipring board.
 
 Arduino UNO R3 has separate I2C pins which is really nice but the Circuits@Home USB Shield covers them up. The R3 Board still has I2C pins at A4 and A5.
 
 I've had better performance using the Mega with I2C because of using the hardware serial pins.
 
-
 ### Controller Pairing
-Power the Arduino up. It will also power up the Receiver.  Press the big button on the receiver, it will blink. Press the center Guide button the controller to turn the controller too. It will blibk. Press the little sync button located on the top edge of the controller. The controller blink too, then they should sync up and the blinking pattern on the controller will change and swirl. This indicates a connection and that they are paired.
+
+Power the Arduino up. It will also power up the Receiver. Press the big button on the receiver, it will blink. Press the center Guide button the controller to turn the controller too. It will blibk. Press the little sync button located on the top edge of the controller. The controller blink too, then they should sync up and the blinking pattern on the controller will change and swirl. This indicates a connection and that they are paired.
 
 There's also the [Xbox Support Guide](http://support.xbox.com/en-US/xbox-on-other-devices/connections/xbox-360-wireless-gaming-receiver-windows).
 
-#### Troubleshooting
-Not triggering sound or getting any movement? Make sure you're paired. The best way is to use the Xbox Wireless library's example sketch.
+### Options, Configurations, and Settings
 
-1. File>Examples>USB Host Shield>Xbox>Xbox Recv
-2. Upload that to your Arduino
-3. Look at the code and you'll see `Serial.begin`. Take note of that number.
-4. Tools>Serial Monitor. Set the baud rate to that number from step 3. 
-5. Pair your controller. 
-
-Press buttons, do you see the button names output? If you don't, you're not paired. If it's paired, you'll see the button names in the serial monitor as you press them. 
+Review the top of the Arduino Sketch that you will be uploading to your droid. There are a number of options and configurations that you may need to tune for YOUR droid specifically. Provided are defaults and standard that generally work well but you may find that based on your drive system, power system, and personal preferences you may want to adjust them. The top of the sketch documents each of these settings and provides defaults and includes explanations and descriptions of what each of them does and potential changes you may want to change. Review these carefully.
 
 ### Teeces Logics
 
@@ -285,28 +273,81 @@ Mike Erwin put out some great boards with Arduino bootloaders on them. Programma
 
 ### Controller LED Status
 
-
-|LEDs Around Center Guide Button   |Description   |
-|---|---|
-| 4 Flashing/Blinking in Unison  | Looking for connection to receiver   |
-| Rotating/Spinning pattern  | Connected to receiver. Foot motors disengaged  |
-| Single LED Top Left - Steady  | Foot Motors Engaged. Speed 1  |
-| Single LED Top Right - Steady  | Foot Motors Engaged. Speed 2  |
-| Single LED Bottom Left - Steady   | Foot Motors Engaged. Speed 3  |
-
+| LEDs Around Center Guide Button | Description                                   |
+| ------------------------------- | --------------------------------------------- |
+| 4 Flashing/Blinking in Unison   | Looking for connection to receiver            |
+| Rotating/Spinning pattern       | Connected to receiver. Foot motors disengaged |
+| Single LED Top Left - Steady    | Foot Motors Engaged. Speed 1                  |
+| Single LED Top Right - Steady   | Foot Motors Engaged. Speed 2                  |
+| Single LED Bottom Left - Steady | Foot Motors Engaged. Speed 3                  |
 
 ### Button Guide
+
 Press guide button to turn on the controller.
 
 Press Start button to engage motors!
 
+Drive stick is now on the LEFT STICK and dome control is on the RIGHT STICK.
+They have been reversed from what is seen in the below controller guide.
+Set `leftHandDrive` in the code to false to drive with the RIGHT STICK as seen in the guide.
+
 ![Button Guide](https://github.com/dankraus/padawan360/blob/master/xbox360-controller-guide.jpg)
 
 (Button layout image courtesy of LarryJ on Astromech. Thanks!)
+
+## Troubleshooting and FAQs
+
+### General Control Issues
+
+Not triggering sound or getting any movement? Make sure you're paired. The best way is to use the Xbox Wireless library's example sketch.
+
+1. File>Examples>USB Host Shield>Xbox>Xbox Recv
+2. Upload that to your Arduino
+3. Look at the code and you'll see `Serial.begin`. Take note of that number.
+4. Tools>Serial Monitor. Set the baud rate to that number from step 3.
+5. Pair your controller.
+
+Press buttons, do you see the button names output? If you don't, you're not paired. If it's paired, you'll see the button names in the serial monitor as you press them.
+
+### Sound
+
+If the MP3 Trigger isn't functioning as expected, or at all, or just behaving a little "odd" - it would be good to make sure you have the most up to date firmware. Version 2.54 is known to work. It can be downloaded [here ](http://robertsonics.com/mp3-trigger-downloads/). The user manual has instruction for installation on the last page (as of this writing) of the instruction manual under "Bootloader". The manual is available from the previous link and also available directly [here](http://robertsonics.com/resources/mp3trigger/MP3TriggerV2UserGuide_2012-02-04.pdf)
+
+Some users had experienced some issues of sounds freezing up and going a bit haywire. It was resolved by using the barrel jack power connector as the Mp3Trigger was browning out. That means that disconnecting the 5v and Ground pins between the Arduino and MP3Trigger and switching flip the switch to EXT.
+
+If the wrong sounds are playing for button presses, they are likely added to the SD card in the wrong order. They must be put on the card in the exact order one at a time or by using Drivesort. Reference [this video](https://youtu.be/UsMI2gW7Q40) for how load the sound files up with Drivesort to ensure they're loaded onto the SD Card in proper order.
+
+### Dome
+
+_**"My Dome just randomly spins!" My Dome won't spin! My Dome doesn't spin correctly** etc etc.._
+
+Depending on the firmware on the Syren, sometimes you need to change the serial baud rate it communicates at. Change this like `const int DOMEBAUDRATE = 2400;` For packetized options are: 2400, 9600, 19200 and 38400
+
+_**The dome spins in the wrong direction when I move the dome control stick!**_
+
+Flip the leads to the dome motor. There is no positive and negative. Orient your controls from the perspective of the droid. Stand behind the droid so that pressing left on the stick makes the dome spin left and right on the stick makes the some spin right.
+
+_**"The left analog stick is centered but the dome still spins!"**_
+
+You need to just adjust the deadzone `const byte DOMEDEADZONERANGE = 20;` Increase this number until you can let the stick go neutral and nothing moves. The code has some more info on that above that line.
+
+### Drives
+
+_When I press left on the drive stick, it turns to the right (or vice versa)!_
+_When I push forward on the drive stick it drives backwards (or vice versa)!_
+
+People often regularly run into this once they power everything up and find that they push forward on the stick and it drives to left, stick to the left drives drives backwards, etc. Don't fret, motors can be wired positive/negative. It doesn't matter. Start flipping the motor connections to the Sabertooth. First flip M1A and M1B. If that doesn't fix it, flip it back and try the other. If it still isn't right, then try flipping both sets. R2 is driven like a tank. Spin the right motor forward to go left, left motor forward to go right. Both motors forward, drive forward. Keep that in mind as you troubleshoot.
+
+Orient your controls from the perspective of the droid. Stand behind the droid so that pressing left on the drive stick makes the droid turn left, right on the stick makes the droid turn right, up on the stick makes the droid drive forward, down on the stick makes the droid drive backwards.
+
+_**Q:** The right analog stick is centered but it still drives(turns, drives forward, drives reverse, etc)!_
+
+**A:** You need to just adjust the deadzone `const byte DRIVEDEADZONERANGE = 20;` Increase this number until you can let the stick go neutral and nothing moves. The code has some more info on that above that line.
 
 ## Coming Soon
 
 Dome servos via I2C support.
 
 ## Licensing
+
 See the LICENSE file in this repository.

--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ Press Start button to engage motors!
 
 Drive stick is now on the LEFT STICK and dome control is on the RIGHT STICK.
 They have been reversed from what is seen in the below controller guide.
-Set `leftHandDrive` in the code to false to drive with the RIGHT STICK as seen in the guide.
+Set `isLeftStickDrive` in the code to false to drive with the RIGHT STICK as seen in the guide.
 
 ![Button Guide](https://github.com/dankraus/padawan360/blob/master/xbox360-controller-guide.jpg)
 
@@ -325,7 +325,8 @@ Depending on the firmware on the Syren, sometimes you need to change the serial 
 
 _**The dome spins in the wrong direction when I move the dome control stick!**_
 
-Flip the leads to the dome motor. There is no positive and negative. Orient your controls from the perspective of the droid. Stand behind the droid so that pressing left on the stick makes the dome spin left and right on the stick makes the some spin right.
+Flip the leads to the dome motor. There is no positive and negative. Orient your controls from the perspective of the droid. Stand behind the droid so that pressing 
+on the stick makes the dome spin left and right on the stick makes the some spin right.
 
 _**The left analog stick is centered but the dome still spins!**_
 

--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ If the wrong sounds are playing for button presses, they are likely added to the
 
 ### Dome
 
-_**"My Dome just randomly spins!" My Dome won't spin! My Dome doesn't spin correctly** etc etc.._
+_**My Dome just randomly spins! My Dome won't spin! My Dome doesn't spin correctly** etc etc.._
 
 Depending on the firmware on the Syren, sometimes you need to change the serial baud rate it communicates at. Change this like `const int DOMEBAUDRATE = 2400;` For packetized options are: 2400, 9600, 19200 and 38400
 
@@ -327,14 +327,13 @@ _**The dome spins in the wrong direction when I move the dome control stick!**_
 
 Flip the leads to the dome motor. There is no positive and negative. Orient your controls from the perspective of the droid. Stand behind the droid so that pressing left on the stick makes the dome spin left and right on the stick makes the some spin right.
 
-_**"The left analog stick is centered but the dome still spins!"**_
+_**The left analog stick is centered but the dome still spins!**_
 
 You need to just adjust the deadzone `const byte DOMEDEADZONERANGE = 20;` Increase this number until you can let the stick go neutral and nothing moves. The code has some more info on that above that line.
 
 ### Drives
 
-_When I press left on the drive stick, it turns to the right (or vice versa)!_
-_When I push forward on the drive stick it drives backwards (or vice versa)!_
+_**When I press left on the drive stick, it turns to the right (or vice versa)! When I push forward on the drive stick it drives backwards (or vice versa)!**_
 
 People often regularly run into this once they power everything up and find that they push forward on the stick and it drives to left, stick to the left drives drives backwards, etc. Don't fret, motors can be wired positive/negative. It doesn't matter. Start flipping the motor connections to the Sabertooth. First flip M1A and M1B. If that doesn't fix it, flip it back and try the other. If it still isn't right, then try flipping both sets. R2 is driven like a tank. Spin the right motor forward to go left, left motor forward to go right. Both motors forward, drive forward. Keep that in mind as you troubleshoot.
 

--- a/padawan360_body/padawan360_body_mega_i2c_ino/padawan360_body_mega_i2c/padawan360_body_mega_i2c.ino
+++ b/padawan360_body/padawan360_body_mega_i2c_ino/padawan360_body_mega_i2c/padawan360_body_mega_i2c.ino
@@ -1,10 +1,11 @@
 // =======================================================================================
-// /////////////////////////Padawan360 Body Code - Mega I2C v1.0 ////////////////////////////////////
+// /////////////////////////Padawan360 Body Code - Mega I2C v2.0 ////////////////////////////////////
 // =======================================================================================
 /*
 by Dan Kraus
 dskraus@gmail.com
 Astromech: danomite4047
+Project Site: https://github.com/dankraus/padawan360/
 
 Heavily influenced by DanF's Padwan code which was built for Arduino+Wireless PS2
 controller leveraging Bill Porter's PS2X Library. I was running into frequent disconnect
@@ -35,20 +36,30 @@ Placed a 10K ohm resistor between S1 & GND on the SyRen 10 itself
 
 */
 
-//************************** Set speed and turn speeds here************************************//
+// ************************** Options, Configurations, and Settings ***********************************
 
+
+// SPEED AND TURN SPEEDS
 //set these 3 to whatever speeds work for you. 0-stop, 127-full speed.
 const byte DRIVESPEED1 = 50;
-//Recommend beginner: 50 to 75, experienced: 100 to 127, I like 100.
+// Recommend beginner: 50 to 75, experienced: 100 to 127, I like 100. 
+// These may vary based on your drive system and power system
 const byte DRIVESPEED2 = 100;
 //Set to 0 if you only want 2 speeds.
 const byte DRIVESPEED3 = 127;
 
+// Default drive speed at startup
 byte drivespeed = DRIVESPEED1;
+
+// Set leftHandDrive to true for driving  with the left stick
+// Set leftHandDrive to false for driving with the right stick (legacy and original configuration)
+boolean leftHandDrive = true; 
 
 // the higher this number the faster the droid will spin in place, lower - easier to control.
 // Recommend beginner: 40 to 50, experienced: 50 $ up, I like 70
+// This may vary based on your drive system and power system
 const byte TURNSPEED = 70;
+
 // If using a speed controller for the dome, sets the top speed. You'll want to vary it potenitally
 // depending on your motor. My Pittman is really fast so I dial this down a ways from top speed.
 // Use a number up to 127 for serial
@@ -69,7 +80,6 @@ const byte RAMPING = 5;
 const byte DOMEDEADZONERANGE = 20;
 const byte DRIVEDEADZONERANGE = 20;
 
-
 // Set the baude rate for the Sabertooth motor controller (feet)
 // 9600 is the default baud rate for Sabertooth packet serial.
 // for packetized options are: 2400, 9600, 19200 and 38400. I think you need to pick one that works
@@ -81,8 +91,18 @@ const int SABERTOOTHBAUDRATE = 9600;
 // and I think it varies across different firmware versions.
 const int DOMEBAUDRATE = 2400;
 
+// Default sound volume at startup
+// 0 = full volume, 255 off
+byte vol = 20;
 
-// I have a pin set to pull a relay high/low to trigger my upside down compressed air like R2's extinguisher
+
+// Automation Delays
+// set automateDelay to min and max seconds between sounds
+byte automateDelay = random(5, 20); 
+//How much the dome may turn during automation.
+int turnDirection = 20;
+
+// Pin number to pull a relay high/low to trigger my upside down compressed air like R2's extinguisher
 #define EXTINGUISHERPIN 3
 
 #include <Sabertooth.h>
@@ -101,26 +121,28 @@ Sabertooth Syren10(128, Serial2);
 #endif
 
 // Set some defaults for start up
-// 0 = full volume, 255 off
-byte vol = 20;
-// 0 = drive motors off ( right stick disabled ) at start
+// false = drive motors off ( right stick disabled ) at start
 boolean isDriveEnabled = false;
 
-// Automated function variables
+// Automated functionality
 // Used as a boolean to turn on/off automated functions like periodic random sounds and periodic dome turns
 boolean isInAutomationMode = false;
 unsigned long automateMillis = 0;
-byte automateDelay = random(5, 20); // set this to min and max seconds between sounds
-//How much the dome may turn during automation.
-int turnDirection = 20;
 // Action number used to randomly choose a sound effect or a dome turn
 byte automateAction = 0;
+
+
 int driveThrottle = 0;
-int rightStick = 0;
+int throttleStickValue = 0;
 int domeThrottle = 0;
 int turnThrottle = 0;
 
 boolean firstLoadOnConnect = false;
+
+AnalogHatEnum throttleAxis;
+AnalogHatEnum turnAxis;
+AnalogHatEnum domeAxis;
+
 
 // this is legacy right now. The rest of the sketch isn't set to send any of this
 // data to another arduino like the original Padawan sketch does
@@ -176,6 +198,16 @@ void setup() {
 
   mp3Trigger.setup();
   mp3Trigger.setVolume(vol);
+
+  if(leftHandDrive) {
+    throttleAxis = LeftHatY;
+    turnAxis = LeftHatX;
+    domeAxis = RightHatX;
+  } else {
+    throttleAxis = RightHatY;
+    turnAxis = RightHatX;
+    domeAxis = LeftHatX;
+  }
 
 
   // Start I2C Bus. The body is the master.
@@ -483,26 +515,28 @@ void loop() {
   }
 
 
+ 
   // FOOT DRIVES
   // Xbox 360 analog stick values are signed 16 bit integer value
   // Sabertooth runs at 8 bit signed. -127 to 127 for speed (full speed reverse and  full speed forward)
   // Map the 360 stick values to our min/max current drive speed
-  rightStick = (map(Xbox.getAnalogHat(RightHatY, 0), -32768, 32767, -drivespeed, drivespeed));
-  if (rightStick > -DRIVEDEADZONERANGE && rightStick < DRIVEDEADZONERANGE) {
+  
+  throttleStickValue = (map(Xbox.getAnalogHat(throttleAxis, 0), -32768, 32767, -drivespeed, drivespeed));
+  if (throttleStickValue > -DRIVEDEADZONERANGE && throttleStickValue < DRIVEDEADZONERANGE) {
     // stick is in dead zone - don't drive
     driveThrottle = 0;
   } else {
-    if (driveThrottle < rightStick) {
-      if (rightStick - driveThrottle < (RAMPING + 1) ) {
+    if (driveThrottle < throttleStickValue) {
+      if (throttleStickValue - driveThrottle < (RAMPING + 1) ) {
         driveThrottle += RAMPING;
       } else {
-        driveThrottle = rightStick;
+        driveThrottle = throttleStickValue;
       }
-    } else if (driveThrottle > rightStick) {
-      if (driveThrottle - rightStick < (RAMPING + 1) ) {
+    } else if (driveThrottle > throttleStickValue) {
+      if (driveThrottle - throttleStickValue < (RAMPING + 1) ) {
         driveThrottle -= RAMPING;
       } else {
-        driveThrottle = rightStick;
+        driveThrottle = throttleStickValue;
       }
     }
   }

--- a/padawan360_body/padawan360_body_mega_i2c_ino/padawan360_body_mega_i2c/padawan360_body_mega_i2c.ino
+++ b/padawan360_body/padawan360_body_mega_i2c_ino/padawan360_body_mega_i2c/padawan360_body_mega_i2c.ino
@@ -51,9 +51,9 @@ const byte DRIVESPEED3 = 127;
 // Default drive speed at startup
 byte drivespeed = DRIVESPEED1;
 
-// Set leftHandDrive to true for driving  with the left stick
-// Set leftHandDrive to false for driving with the right stick (legacy and original configuration)
-boolean leftHandDrive = true; 
+// Set isLeftStickDrive to true for driving  with the left stick
+// Set isLeftStickDrive to false for driving with the right stick (legacy and original configuration)
+boolean isLeftStickDrive = true; 
 
 // the higher this number the faster the droid will spin in place, lower - easier to control.
 // Recommend beginner: 40 to 50, experienced: 50 $ up, I like 70
@@ -199,7 +199,7 @@ void setup() {
   mp3Trigger.setup();
   mp3Trigger.setVolume(vol);
 
-  if(leftHandDrive) {
+  if(isLeftStickDrive) {
     throttleAxis = LeftHatY;
     turnAxis = LeftHatX;
     domeAxis = RightHatX;

--- a/padawan360_body/padawan360_body_mega_i2c_ino/padawan360_body_mega_i2c/padawan360_body_mega_i2c.ino
+++ b/padawan360_body/padawan360_body_mega_i2c_ino/padawan360_body_mega_i2c/padawan360_body_mega_i2c.ino
@@ -16,6 +16,9 @@ support for PS3 and Xbox 360 controllers. Bluetooth dongles were inconsistent as
 so I wanted to be able to have something with parts that other builder's could easily track
 down and buy parts even at your local big box store.
 
+v2.0 Changes:
+- Makes left analog stick default drive control stick. Configurable between left or right stick via isLeftStickDrive 
+
 Hardware:
 ***Arduino Mega 2560***
 USB Host Shield from circuits@home
@@ -51,14 +54,14 @@ const byte DRIVESPEED3 = 127;
 // Default drive speed at startup
 byte drivespeed = DRIVESPEED1;
 
-// Set isLeftStickDrive to true for driving  with the left stick
-// Set isLeftStickDrive to false for driving with the right stick (legacy and original configuration)
-boolean isLeftStickDrive = true; 
-
 // the higher this number the faster the droid will spin in place, lower - easier to control.
 // Recommend beginner: 40 to 50, experienced: 50 $ up, I like 70
 // This may vary based on your drive system and power system
 const byte TURNSPEED = 70;
+
+// Set isLeftStickDrive to true for driving  with the left stick
+// Set isLeftStickDrive to false for driving with the right stick (legacy and original configuration)
+boolean isLeftStickDrive = true; 
 
 // If using a speed controller for the dome, sets the top speed. You'll want to vary it potenitally
 // depending on your motor. My Pittman is really fast so I dial this down a ways from top speed.
@@ -142,6 +145,8 @@ boolean firstLoadOnConnect = false;
 AnalogHatEnum throttleAxis;
 AnalogHatEnum turnAxis;
 AnalogHatEnum domeAxis;
+ButtonEnum speedSelectButton;
+ButtonEnum hpLightToggleButton;
 
 
 // this is legacy right now. The rest of the sketch isn't set to send any of this
@@ -203,10 +208,15 @@ void setup() {
     throttleAxis = LeftHatY;
     turnAxis = LeftHatX;
     domeAxis = RightHatX;
+    speedSelectButton = L3;
+    hpLightToggleButton = R3;
+
   } else {
     throttleAxis = RightHatY;
     turnAxis = RightHatX;
     domeAxis = LeftHatX;
+    speedSelectButton = R3;
+    hpLightToggleButton = L3;
   }
 
 
@@ -470,8 +480,9 @@ void loop() {
     }
   }
 
-  // turn hp light on & off with Left Analog Stick Press (L3)
-  if (Xbox.getButtonClick(L3, 0))  {
+  // turn hp light on & off with Right Analog Stick Press (R3) for left stick drive mode
+  // turn hp light on & off with Left Analog Stick Press (L3) for right stick drive mode
+  if (Xbox.getButtonClick(hpLightToggleButton, 0))  {
     // if hp light is on, turn it off
     if (isHPOn) {
       isHPOn = false;
@@ -487,10 +498,11 @@ void loop() {
   }
 
 
-  // Change drivespeed if drive is eabled
-  // Press Right Analog Stick (R3)
+  // Change drivespeed if drive is enabled
+  // Press Left Analog Stick (L3) for left stick drive mode
+  // Press Right Analog Stick (R3) for right stick drive mode
   // Set LEDs for speed - 1 LED, Low. 2 LED - Med. 3 LED High
-  if (Xbox.getButtonClick(R3, 0) && isDriveEnabled) {
+  if (Xbox.getButtonClick(speedSelectButton, 0) && isDriveEnabled) {
     //if in lowest speed
     if (drivespeed == DRIVESPEED1) {
       //change to medium speed and play sound 3-tone

--- a/padawan360_body/padawan360_body_mega_i2c_ino/padawan360_body_mega_i2c/padawan360_body_mega_i2c.ino
+++ b/padawan360_body/padawan360_body_mega_i2c_ino/padawan360_body_mega_i2c/padawan360_body_mega_i2c.ino
@@ -220,7 +220,7 @@ void setup() {
   }
 
 
-  // Start I2C Bus. The body is the master.
+ // Start I2C Bus. The body is the master.
   Wire.begin();
 
   //Serial.begin(115200);
@@ -532,7 +532,6 @@ void loop() {
   // Xbox 360 analog stick values are signed 16 bit integer value
   // Sabertooth runs at 8 bit signed. -127 to 127 for speed (full speed reverse and  full speed forward)
   // Map the 360 stick values to our min/max current drive speed
-  
   throttleStickValue = (map(Xbox.getAnalogHat(throttleAxis, 0), -32768, 32767, -drivespeed, drivespeed));
   if (throttleStickValue > -DRIVEDEADZONERANGE && throttleStickValue < DRIVEDEADZONERANGE) {
     // stick is in dead zone - don't drive
@@ -553,7 +552,7 @@ void loop() {
     }
   }
 
-  turnThrottle = map(Xbox.getAnalogHat(RightHatX, 0), -32768, 32767, -TURNSPEED, TURNSPEED);
+  turnThrottle = map(Xbox.getAnalogHat(turnAxis, 0), -32768, 32767, -TURNSPEED, TURNSPEED);
 
   // DRIVE!
   // right stick (drive)
@@ -569,7 +568,7 @@ void loop() {
   }
 
   // DOME DRIVE!
-  domeThrottle = (map(Xbox.getAnalogHat(LeftHatX, 0), -32768, 32767, DOMESPEED, -DOMESPEED));
+  domeThrottle = (map(Xbox.getAnalogHat(domeAxis, 0), -32768, 32767, DOMESPEED, -DOMESPEED));
   if (domeThrottle > -DOMEDEADZONERANGE && domeThrottle < DOMEDEADZONERANGE) {
     //stick in dead zone - don't spin dome
     domeThrottle = 0;


### PR DESCRIPTION
There was interest in a left stick drive version. Understandably so as it makes sense for traditional game pad controls in video games.

The original version, right stick drive control derives from RC plane control with throttle on the right stick. 

Left stick control is now DEFAULT but there is an configurable option of `isLeftStickDrive` boolean to set to false to go back to right stick control.

This has yet to be tested on a droid as I'm not near one or able to test personally for some time. I would love to have someone confirm it works and I will also update the Arduino UNO version of the code in this Pull Request as well.

There has also been some restructuring of the code to pull configurable options closer together with additional comments in the code to explain them.

The README has also been restructured a bit with some additional notes about the above new feature.